### PR TITLE
Travis pytest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: python
+
+services:
+  - docker
+
+python:
+  - 2.7
+
+before_install:
+  - docker build --build-arg base_image=tensorflow/tensorflow:1.12.0 -t imit-learn .
+
+script:
+  - docker run --rm imit-learn pytest
+
+notifications:
+    email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_install:
   - docker build --build-arg base_image=tensorflow/tensorflow:1.12.0 -t imit-learn .
 
 script:
-  - docker run --rm imit-learn pytest
+  - docker run --rm -v $TRAVIS_BUILD_DIR/imitation:/imitation -v $(pwd)/data:/data imit-learn pytest
 
 notifications:
     email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_install:
   - docker build --build-arg base_image=tensorflow/tensorflow:1.12.0 -t imit-learn .
 
 script:
-  - docker run --rm -v $TRAVIS_BUILD_DIR/imitation:/imitation -v $(pwd)/data:/data imit-learn pytest
+  - docker run --rm -v "$TRAVIS_BUILD_DIR/imitation:/imitation" -v "$TRAVIS_BUILD_DIR/data:/data" imit-learn pytest
 
 notifications:
     email: false

--- a/README.md
+++ b/README.md
@@ -21,10 +21,6 @@ This repository uses docker images. In order to use it, install [docker](https:/
 To build the image, use:
 
 ```bash
-cd <root of this repository>
-DOCKER_BASH_HISTORY="$(pwd)/data/docker.bash_history"
-touch $DOCKER_BASH_HISTORY
-
 docker build --build-arg base_image=tensorflow/tensorflow:1.12.0-gpu -t imit-learn .
 ```
 
@@ -32,8 +28,16 @@ If you only need a CPU image, leave out `base_image=tensorflow/tensorflow:1.12.0
 So far, we only tested the setup with Python2, which `tensorflow:1.12.0` is based on.
 
 To run a container, use:
-```
-docker run -it --rm --name imit_learn -v $(pwd)/imitation:/imitation -v $(pwd)/data:/data -v "$DOCKER_BASH_HISTORY:/root/.bash_history" imit-learn bash
+
+```bash
+cd <root of this repository>
+DOCKER_BASH_HISTORY="$(pwd)/data/docker.bash_history"
+touch $DOCKER_BASH_HISTORY
+
+docker run -it --rm --name imit_learn \ 
+    -v $(pwd)/imitation:/imitation -v $(pwd)/data:/data \
+    -v "$DOCKER_BASH_HISTORY:/root/.bash_history" \
+    imit-learn bash
 ```
 
 Download [dataset](https://github.com/carla-simulator/imitation-learning/#user-content-dataset) (24GB).

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Imitation learning
+# Imitation learning [![Build Status](https://travis-ci.org/merantix/imitation-learning.svg?branch=master)](https://travis-ci.org/merantix/imitation-learning)
 
 
 This repository provides a Tensorflow implementation of the paper 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 argparse==1.2.1
+pyyaml==3.13
 future==0.16.0
 ipdb==0.11
 numpy==1.14.5


### PR DESCRIPTION
**Motivation:**
We want to provide a basic idea that the current code is working (Continuous Integration). We chose travis as an easy and free option to do this.

**Changes:**
- Add `.travis.yml` that builds and runs the docker image and runs the pytest command
- Adjust README
- Fix minor bug: `pyyaml` dependency was missing