### PR TITLE
Speedup training through num_parallel_calls

### DIFF
--- a/imitation/input_fn.py
+++ b/imitation/input_fn.py
@@ -97,7 +97,7 @@ class CarlaPreprocessor(Preprocessor):
         Returns:
             a tf.data.Dataset
         """
-        dataset = dataset.map(self.read_fn)
+        dataset = dataset.map(self.read_fn, num_parallel_calls=16)
         return dataset
 
     @staticmethod
@@ -143,7 +143,7 @@ class ProbabilisticImageAugmentor(Preprocessor):
 
     def preprocess(self, dataset, mode):
         assert mode == tf.estimator.ModeKeys.TRAIN, 'Should not augment eval / inference'
-        return dataset.map(self.apply_to_image)
+        return dataset.map(self.apply_to_image, num_parallel_calls=16)
 
 
 def _rand_gauss_blur(img):
@@ -218,5 +218,6 @@ def evaluation_input_fn(tfrecord_fpaths, batch_size):
         mode=tf.estimator.ModeKeys.EVAL,
         num_epochs=1,
         model_preprocessors=[FilterValidIntention(), CarlaPreprocessor()],
+        num_parallel_calls=16,
     )
     return input_fn


### PR DESCRIPTION
Make training faster by using num_parallel_calls parameter: This means that the input pipeline's preprocessing will run computation in parallel now.

The speedup depends on the hardware obviously, but we measured a 2.6x speedup for our setup.